### PR TITLE
Fix grep ignore other subdomains

### DIFF
--- a/dynamicdns.bash
+++ b/dynamicdns.bash
@@ -305,7 +305,7 @@ function deleteRecord {
     return 1
   fi
 
-  local CURRENT_RECORD=`echo $LIST_RESP | egrep -o "$RECORD\s+A\s+[0-9]{,3}.[0-9]{,3}.[0-9]{,3}.[0-9]{,3}"`
+  local CURRENT_RECORD=`echo $LIST_RESP | egrep -o "\s$RECORD\s+A\s+[0-9]{,3}.[0-9]{,3}.[0-9]{,3}.[0-9]{,3}"`
   if [ $VERBOSE = "true" ]; then
     echo "Current Record: $CURRENT_RECORD"
   fi


### PR DESCRIPTION
Added the missing \s that was causing the script to try to update subdomain records when using on the root domain.

Closes #9 

Thanks
John