### PR TITLE
Tell dig to use IPv4

### DIFF
--- a/dynamicdns.bash
+++ b/dynamicdns.bash
@@ -225,7 +225,7 @@ if [ ! -n "$OPTIP" ]; then
 	if [ $VERBOSE = "true" ]; then
 		echo "No IP Address provided, obtaining public IP"
 	fi
-	IP=$(eval "dig +short myip.opendns.com @resolver1.opendns.com")
+	IP=$(eval "dig -4 +short myip.opendns.com @resolver1.opendns.com")
 	if [ $? -ne 0 ]; then
 		logStatus "error" "Failed to obtain current IP address"
 		exit 3


### PR DESCRIPTION
As we only currently support updating `A` records (and not `AAAA`) we should tell `dig` that we want to use IPv4.

Fixes #11.