### PR TITLE
Update dreamhost panel api url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ TODO
 - Allow disabling of error logging
 - Add verbose mode
 
-[panel]: https://panel.dreamhost.com/=======
+[panel]: https://panel.dreamhost.com/?tree=home.api
 


### PR DESCRIPTION
The url for the API management in Dreamhost Panel was broken. Updated it to: https://panel.dreamhost.com/?tree=home.api